### PR TITLE
Fix DAI approval being always requested

### DIFF
--- a/packages/contract-helpers/src/psm-contract/index.ts
+++ b/packages/contract-helpers/src/psm-contract/index.ts
@@ -66,13 +66,11 @@ export class PsmService extends BaseService<DssPsm> implements PsmServiceInterfa
         const { decimalsOf, isApproved, approve } = this.erc20Service;
         const decimals: number = await decimalsOf(this.tokenAddress);
         const convertedAmount: string = valueToWei(gemAmt, decimals);
-        const decimalsDai: number = await decimalsOf(this.daiAddress);
-        const convertedAmountDai: string = valueToWei(gemAmt, decimalsDai);
         const approved: boolean = await isApproved({
             token: this.daiAddress,
             user: userAddress,
             spender: this.psmAddress,
-            amount: convertedAmountDai,
+            amount: gemAmt,
         });
         if (!approved) {
             const approveTx = approve({
@@ -117,7 +115,7 @@ export class PsmService extends BaseService<DssPsm> implements PsmServiceInterfa
             token: this.tokenAddress,
             user: userAddress,
             spender: gemJoinAddress,
-            amount: convertedAmount,
+            amount: gemAmt,
         });
         if (!approved) {
             const approveTx = approve({

--- a/packages/contract-helpers/src/savings-dai-contract/index.ts
+++ b/packages/contract-helpers/src/savings-dai-contract/index.ts
@@ -75,7 +75,7 @@ export class SavingsDaiService extends BaseService<ISavingsDai> implements Savin
             token: this.daiAddress,
             user: userAddress,
             spender: this.savingsDaiAddress,
-            amount: convertedAmount,
+            amount: assets,
         });
         if (!approved) {
             const approveTx = approve({


### PR DESCRIPTION
Currently, while swapping to sDAI, DAI approval is always requested. It was caused by passing WEI denominated number to `isApproved` function instead of the base value. 

Conversion happens inside of `isApproved` method: https://github.com/marsfoundation/spark-utilities/blob/master/packages/contract-helpers/src/erc20-contract/index.ts#L100

Example of correct usage: https://github.com/marsfoundation/spark-utilities/blob/master/packages/contract-helpers/src/staking-contract/index.ts#L200